### PR TITLE
Use `expecteds` as an iterator not `expected`.

### DIFF
--- a/lib/rspec-solr/include_documents_matcher.rb
+++ b/lib/rspec-solr/include_documents_matcher.rb
@@ -70,7 +70,7 @@ module RSpec
         def excluded_from_actual
           return [] unless @actual.respond_to?(:include?)
 
-          expected.each_with_object([]) do |expected_item, memo|
+          expecteds.each_with_object([]) do |expected_item, memo|
             if comparing_doc_to_solr_resp_hash?(expected_item)
               if @before_expected
                 before_ix = actual.get_first_doc_index(@before_expected)


### PR DESCRIPTION
I think this may have been added by mistake in
69683ff244af92d5e1c84b023805b12e6109e106 . But the rspec-expectations
method that this overrides uses `expecteds` and this fixes 17 failing
tests.